### PR TITLE
Ansible2: Use full variable syntax ('{{aliases}}') and "become"

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,3 @@
 - name: update aliases database
   command: newaliases
-  sudo: yes
+  become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,5 +4,5 @@
     line: "{{ item.user }}: {{ item.alias }}"
     regexp: "^{{ item.user }}:"
   with_items: '{{aliases}}'
-  sudo: yes
+  become: yes
   notify: update aliases database

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,6 @@
     dest: /etc/aliases
     line: "{{ item.user }}: {{ item.alias }}"
     regexp: "^{{ item.user }}:"
-  with_items: aliases
+  with_items: '{{aliases}}'
   sudo: yes
   notify: update aliases database


### PR DESCRIPTION
As of Ansible 2.0 using bare variables is deprecated[1]; Use full variable
syntax instead.

Also use "become" instead of "sudo".

[1] https://docs.ansible.com/ansible/porting_guide_2.0.html
